### PR TITLE
ModuleManager error on TranquilityTemplates.cfg

### DIFF
--- a/GameData/WildBlueIndustries/DSEV/Templates/Common/TranquilityTemplates.cfg
+++ b/GameData/WildBlueIndustries/DSEV/Templates/Common/TranquilityTemplates.cfg
@@ -155,19 +155,19 @@ TRANQ
 	toolTipTitle = Your First Mark Two Habitat
 }
 
-@TRANQ:FOR[DSEV]:NEEDS[Launchpad]
+TRANQ:NEEDS[Launchpad]
 {
-	@author = Angel-125
-	@name = EL Survey Station
-	@mass = 2.5
-	@requiredResource = Equipment
-	@requiredAmount = 1000
-	@reconfigureSkill = ConverterSkill
-	@logoPanel = WildBlueIndustries/000WildBlueTools/Decals/RocketParts
-	@glowPanel = WildBlueIndustries/000WildBlueTools/Decals/RocketParts
-	@description = The Survey station is designed to oversee construction of new vessels. It requires at least one pilot and nearby survey stakes to operate properly.
-	@toolTip = Now you can supervise rocket construction- don't forget your survey stakes!
-	@toolTipTitle = Survey Station
+	author = Angel-125
+	name = EL Survey Station
+	mass = 2.5
+	requiredResource = Equipment
+	requiredAmount = 1000
+	reconfigureSkill = ConverterSkill
+	logoPanel = WildBlueIndustries/000WildBlueTools/Decals/RocketParts
+	glowPanel = WildBlueIndustries/000WildBlueTools/Decals/RocketParts
+	description = The Survey station is designed to oversee construction of new vessels. It requires at least one pilot and nearby survey stakes to operate properly.
+	toolTip = Now you can supervise rocket construction- don't forget your survey stakes!
+	toolTipTitle = Survey Station
 	templateTags = dsevHab
 
 	MODULE 

--- a/GameData/WildBlueIndustries/DSEV/Templates/Common/TranquilityTemplates.cfg
+++ b/GameData/WildBlueIndustries/DSEV/Templates/Common/TranquilityTemplates.cfg
@@ -155,19 +155,19 @@ TRANQ
 	toolTipTitle = Your First Mark Two Habitat
 }
 
-TRANQ:FOR[DSEV]:NEEDS[Launchpad]
+@TRANQ:FOR[DSEV]:NEEDS[Launchpad]
 {
-	author = Angel-125
-	name = EL Survey Station
-	mass = 2.5
-	requiredResource = Equipment
-	requiredAmount = 1000
-	reconfigureSkill = ConverterSkill
-	logoPanel = WildBlueIndustries/000WildBlueTools/Decals/RocketParts
-	glowPanel = WildBlueIndustries/000WildBlueTools/Decals/RocketParts
-	description = The Survey station is designed to oversee construction of new vessels. It requires at least one pilot and nearby survey stakes to operate properly.
-	toolTip = Now you can supervise rocket construction- don't forget your survey stakes!
-	toolTipTitle = Survey Station
+	@author = Angel-125
+	@name = EL Survey Station
+	@mass = 2.5
+	@requiredResource = Equipment
+	@requiredAmount = 1000
+	@reconfigureSkill = ConverterSkill
+	@logoPanel = WildBlueIndustries/000WildBlueTools/Decals/RocketParts
+	@glowPanel = WildBlueIndustries/000WildBlueTools/Decals/RocketParts
+	@description = The Survey station is designed to oversee construction of new vessels. It requires at least one pilot and nearby survey stakes to operate properly.
+	@toolTip = Now you can supervise rocket construction- don't forget your survey stakes!
+	@toolTipTitle = Survey Station
 	templateTags = dsevHab
 
 	MODULE 


### PR DESCRIPTION
@Angel-125 I got a little error thrown by Module Manger on the last version of DSEV :

    [ModuleManager] Error - pass specifier detected on an insert node (not a patch): WildBlueIndustries/DSEV/Templates/Common/TranquilityTemplates/TRANQ:FOR[DSEV]

You'll need to add a "@" so MM understand you modify, and not insert, a node. A few others "@" are also needed to edit the existing variable instead of duplicating them.

This pull request should take care of it. (I've tested it).